### PR TITLE
UE-2696: Make a simple wrapper for mesh compression

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -553,6 +553,38 @@ set(draco_version_sources
 
 include_directories("${draco_root}/src")
 
+option(PSY_DRACO_COMPRESSION_ONLY "Enable psy draco compression only." ON)
+set(psy_draco_compression_sources
+    ${draco_attributes_sources}
+    ${draco_compression_attributes_dec_sources}
+    ${draco_compression_attributes_enc_sources}
+    ${draco_compression_attributes_pred_schemes_dec_sources}
+    ${draco_compression_attributes_pred_schemes_enc_sources}
+    ${draco_compression_decode_sources}
+    ${draco_compression_encode_sources}
+    ${draco_compression_mesh_dec_sources}
+    ${draco_compression_mesh_enc_sources}
+    ${draco_compression_point_cloud_dec_sources}
+    ${draco_compression_point_cloud_enc_sources}
+    ${draco_core_sources}
+    ${draco_core_bit_coders_sources}
+    ${draco_dec_config_sources}
+    ${draco_enc_config_sources}
+    ${draco_io_sources}
+    ${draco_mesh_sources}
+    ${draco_metadata_dec_sources}
+    ${draco_metadata_enc_sources}
+    ${draco_metadata_sources}
+    ${draco_point_cloud_sources}
+    ${draco_points_dec_sources}
+    ${draco_points_enc_sources}
+    ${draco_version_sources}
+    "${draco_src_root}/psy/psy_draco.h"
+    "${draco_src_root}/psy/psy_draco_decoder.cpp"
+    "${draco_src_root}/psy/psy_draco_decoder.h"
+    "${draco_src_root}/psy/psy_draco_encoder.cpp"
+    "${draco_src_root}/psy/psy_draco_encoder.h")
+
 #
 # Draco targets.
 #
@@ -687,6 +719,19 @@ if (EMSCRIPTEN)
   em_link_post_js(draco_encoder
                   "${draco_build_dir}/glue_encoder.js"
                   "${draco_src_root}/javascript/emscripten/finalize.js")
+elseif(PSY_DRACO_COMPRESSION_ONLY)
+  if (MSVC)
+      # because draco 3d has not yet supported for visual studio 2013
+      # we need to create a simple wrapper and compile it on visual studio 2015
+      # - if we compile it onto a static lib, we will get linking error due to mismatch between two visual studio versions
+      # - so, we're compiling the project as shared lib here
+      add_definitions(-DPSY_DRACO_EXPORT=1)
+      add_library(psy_draco_compression SHARED ${psy_draco_compression_sources})
+      set_target_properties(psy_draco_compression PROPERTIES SOVERSION 1)
+  else()
+      # for consitency supporting on windows, we're also creating a wrapper for other platform
+      add_library(psy_draco_compression ${psy_draco_compression_sources})
+  endif()
 else ()
   # Standard Draco libs, encoder and decoder.
   # Object collections that mirror the Draco directory structure.
@@ -763,50 +808,6 @@ else ()
               $<TARGET_OBJECTS:draco_metadata_enc>
               $<TARGET_OBJECTS:draco_point_cloud>
               $<TARGET_OBJECTS:draco_points_enc>)
-
-  set(psy_draco_compression_sources
-      ${draco_attributes_sources}
-      ${draco_compression_attributes_dec_sources}
-      ${draco_compression_attributes_enc_sources}
-      ${draco_compression_attributes_pred_schemes_dec_sources}
-      ${draco_compression_attributes_pred_schemes_enc_sources}
-      ${draco_compression_decode_sources}
-      ${draco_compression_encode_sources}
-      ${draco_compression_mesh_dec_sources}
-      ${draco_compression_mesh_enc_sources}
-      ${draco_compression_point_cloud_dec_sources}
-      ${draco_compression_point_cloud_enc_sources}
-      ${draco_core_sources}
-      ${draco_core_bit_coders_sources}
-      ${draco_dec_config_sources}
-      ${draco_enc_config_sources}
-      ${draco_io_sources}
-      ${draco_mesh_sources}
-      ${draco_metadata_dec_sources}
-      ${draco_metadata_enc_sources}
-      ${draco_metadata_sources}
-      ${draco_point_cloud_sources}
-      ${draco_points_dec_sources}
-      ${draco_points_enc_sources}
-      ${draco_version_sources}
-      "${draco_src_root}/psy/psy_draco.h"
-      "${draco_src_root}/psy/psy_draco_decoder.cpp"
-      "${draco_src_root}/psy/psy_draco_decoder.h"
-      "${draco_src_root}/psy/psy_draco_encoder.cpp"
-      "${draco_src_root}/psy/psy_draco_encoder.h")
-  if (MSVC)
-      # because draco 3d has not yet supported for visual studio 2013
-      # we need to create a simple wrapper and compile it on visual studio 2015
-      # - if we compile it onto a static lib, we will get linking error due to mismatch between two visual studio versions
-      # - so, we're compiling the project as shared lib here
-      add_definitions(-DPSY_DRACO_EXPORT=1)
-      add_library(psy_draco_compression SHARED ${psy_draco_compression_sources})
-      set_target_properties(psy_draco_compression PROPERTIES SOVERSION 1)
-  else()
-      # for consitency supporting on windows, we're also creating a wrapper for other platform
-      add_library(psy_draco_compression ${psy_draco_compression_sources})
-  endif()
-
   add_library(draco
               ${draco_version_sources}
               $<TARGET_OBJECTS:draco_attributes>

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -763,6 +763,50 @@ else ()
               $<TARGET_OBJECTS:draco_metadata_enc>
               $<TARGET_OBJECTS:draco_point_cloud>
               $<TARGET_OBJECTS:draco_points_enc>)
+
+  set(psy_draco_compression_sources
+      ${draco_attributes_sources}
+      ${draco_compression_attributes_dec_sources}
+      ${draco_compression_attributes_enc_sources}
+      ${draco_compression_attributes_pred_schemes_dec_sources}
+      ${draco_compression_attributes_pred_schemes_enc_sources}
+      ${draco_compression_decode_sources}
+      ${draco_compression_encode_sources}
+      ${draco_compression_mesh_dec_sources}
+      ${draco_compression_mesh_enc_sources}
+      ${draco_compression_point_cloud_dec_sources}
+      ${draco_compression_point_cloud_enc_sources}
+      ${draco_core_sources}
+      ${draco_core_bit_coders_sources}
+      ${draco_dec_config_sources}
+      ${draco_enc_config_sources}
+      ${draco_io_sources}
+      ${draco_mesh_sources}
+      ${draco_metadata_dec_sources}
+      ${draco_metadata_enc_sources}
+      ${draco_metadata_sources}
+      ${draco_point_cloud_sources}
+      ${draco_points_dec_sources}
+      ${draco_points_enc_sources}
+      ${draco_version_sources}
+      "${draco_src_root}/psy/psy_draco.h"
+      "${draco_src_root}/psy/psy_draco_decoder.cpp"
+      "${draco_src_root}/psy/psy_draco_decoder.h"
+      "${draco_src_root}/psy/psy_draco_encoder.cpp"
+      "${draco_src_root}/psy/psy_draco_encoder.h")
+  if (MSVC)
+      # because draco 3d has not yet supported for visual studio 2013
+      # we need to create a simple wrapper and compile it on visual studio 2015
+      # - if we compile it onto a static lib, we will get linking error due to mismatch between two visual studio versions
+      # - so, we're compiling the project as shared lib here
+      add_definitions(-DPSY_DRACO_EXPORT=1)
+      add_library(psy_draco_compression SHARED ${psy_draco_compression_sources})
+      set_target_properties(psy_draco_compression PROPERTIES SOVERSION 1)
+  else()
+      # for consitency supporting on windows, we're also creating a wrapper for other platform
+      add_library(psy_draco_compression ${psy_draco_compression_sources})
+  endif()
+
   add_library(draco
               ${draco_version_sources}
               $<TARGET_OBJECTS:draco_attributes>

--- a/src/draco/core/options.h
+++ b/src/draco/core/options.h
@@ -18,6 +18,21 @@
 #include <cstdlib>
 #include <map>
 #include <string>
+#include <sstream>
+
+#if ANDROID
+namespace std {
+
+template <typename T>
+std::string to_string(T value)
+{
+    std::ostringstream os;
+    os << value;
+    return os.str();
+}
+
+}
+#endif
 
 namespace draco {
 
@@ -105,7 +120,7 @@ bool Options::GetVector(const std::string &name, int num_dims,
       act_str = next_str;
       out_val[i] = static_cast<DataTypeT>(val);
     } else {
-      const float val = std::strtof(act_str, &next_str);
+      const float val = strtof(act_str, &next_str);
       if (act_str == next_str)
         return true;  // End reached.
       act_str = next_str;

--- a/src/draco/psy/psy_draco.h
+++ b/src/draco/psy/psy_draco.h
@@ -1,0 +1,31 @@
+/*
+* @file psy_draco.h
+*
+* Copyright (c) 2017 Personify Inc.
+*
+* @brief
+*
+*/
+
+#ifndef PSY_DRACO_COMMON_H
+#define PSY_DRACO_COMMON_H
+
+#if defined (WIN32)
+#    ifdef PSY_DRACO_STATIC_LIB
+#        define PSY_DRACO_API
+#    else
+#        ifdef PSY_DRACO_EXPORT
+#            define PSY_DRACO_API __declspec(dllexport)
+#        else
+#            define PSY_DRACO_API __declspec(dllimport)
+#        endif
+#    endif
+#else
+#    ifdef PSY_DRACO_EXPORT
+#        define PSY_DRACO_API __attribute__((visibility("default")))
+#    else
+#        define PSY_DRACO_API
+#    endif
+#endif
+
+#endif // PSY_DRACO_COMMON_H

--- a/src/draco/psy/psy_draco_decoder.cpp
+++ b/src/draco/psy/psy_draco_decoder.cpp
@@ -1,0 +1,205 @@
+/*
+* @file MeshCompression.cpp
+*
+* Copyright (c) 2016 Personify Inc.
+*
+* @brief
+*   Implements mesh MeshCompression
+*/
+
+#include "psy_draco_decoder.h"
+#include "draco/compression/decode.h"
+#include "draco/attributes/point_attribute.h"
+
+namespace psy
+{
+namespace draco
+{
+
+class MeshDecompression::Impl
+{
+public:
+    Impl()
+    {
+        mpMesh.reset(new ::draco::Mesh());
+        mpBuffer.reset(new ::draco::DecoderBuffer());
+        mpDecoder.reset(new ::draco::Decoder());
+    }
+
+    ~Impl()
+    {
+        mpMesh.reset();
+        mpBuffer.reset();
+        mpDecoder.reset();
+    }
+
+    MeshDecompression::eStatus Run(const char* pCompressedData,
+                                   const size_t compressedDataSizeInBytes)
+    {
+        mpBuffer->Init(pCompressedData, compressedDataSizeInBytes);
+
+        const auto type_statusor = ::draco::Decoder::GetEncodedGeometryType(mpBuffer.get());
+        mStatus = type_statusor.status();
+        if (!type_statusor.ok())
+        {   
+            return eStatus::FAILED;
+        }
+
+        const ::draco::EncodedGeometryType geom_type = type_statusor.value();
+        if (geom_type != ::draco::TRIANGULAR_MESH)
+        {
+            mStatus = ::draco::Status(::draco::Status::Code::ERROR,
+                                      "invalid encoded geometry type");
+            return eStatus::FAILED;
+        }
+
+        auto statusor = mpDecoder->DecodeMeshFromBuffer(mpBuffer.get());
+        if (!statusor.ok())
+        {
+            mStatus = statusor.status();
+            return eStatus::FAILED;
+        }
+
+        mpMesh = std::move(statusor).value();
+
+        return eStatus::SUCCEED;
+    }
+
+    void UpdateGeometryAttributeValues(const ::draco::PointAttribute* pPointAttribute,
+                                       uint8_t* pValues,
+                                       const size_t stride,
+                                       const size_t verticesCount) const
+    {
+        const size_t data_sz_in_bytes = pPointAttribute->byte_stride();
+        const auto src_stride = pPointAttribute->byte_stride();
+        uint8_t* p_dst = pValues;
+        if (pPointAttribute->is_mapping_identity())
+        {
+            const uint8_t* p_src = pPointAttribute->buffer()->data();
+            if (stride == src_stride)
+            {
+                memcpy(p_dst, p_src, verticesCount * data_sz_in_bytes);
+            }
+            else
+            {
+                for (size_t i = 0; i < verticesCount; ++i, p_dst += stride, p_src += src_stride)
+                {
+                    memcpy(p_dst, p_src, data_sz_in_bytes);
+                }
+            }
+        }
+        else
+        {
+            ::draco::PointIndex pt_idx(0);
+            for (size_t i = 0; i < verticesCount; ++i, pt_idx++, p_dst += stride)
+            {
+                memcpy(p_dst, pPointAttribute->GetAddressOfMappedIndex(pt_idx), data_sz_in_bytes);
+            }
+        }
+    }
+
+    void GetMesh(float* pVertices,
+                 const size_t vertexStride,
+                 unsigned int* pIndices,
+                 unsigned char* pVisibilityAttributes) const
+    {
+        // update faces
+        {
+            const auto faces_count = mpMesh->num_faces();
+            ::draco::FaceIndex face_index(0);
+            for (int32_t i = 0, j = 0; i < faces_count; i++, face_index++)
+            {
+                const auto& face = mpMesh->face(face_index);
+                pIndices[j++] = static_cast<unsigned int>(face[0].value());
+                pIndices[j++] = static_cast<unsigned int>(face[1].value());
+                pIndices[j++] = static_cast<unsigned int>(face[2].value());
+            }
+        }
+
+        // update vertices
+        {
+            const int pos_att_id = mpMesh->GetNamedAttributeId(::draco::GeometryAttribute::POSITION);
+            assert(pos_att_id >= 0);
+            UpdateGeometryAttributeValues(mpMesh->attribute(pos_att_id),
+                                          reinterpret_cast<uint8_t*>(pVertices),
+                                          vertexStride,
+                                          mpMesh->num_points());
+        }
+
+        // update visibility attribute
+        if (nullptr != pVisibilityAttributes)
+        {
+            const int vis_att_id = mpMesh->GetNamedAttributeId(::draco::GeometryAttribute::GENERIC);
+            assert(vis_att_id >= 0);
+            UpdateGeometryAttributeValues(mpMesh->attribute(vis_att_id),
+                                          pVisibilityAttributes,
+                                          sizeof(uint8_t),
+                                          mpMesh->num_points());
+        }
+    }
+
+    std::unique_ptr<::draco::Mesh> mpMesh;
+    std::unique_ptr<::draco::DecoderBuffer> mpBuffer;
+    std::unique_ptr<::draco::Decoder> mpDecoder;
+    ::draco::Status mStatus;
+};
+
+MeshDecompression:: MeshDecompression()
+{
+    mpImpl = new Impl();
+}
+
+MeshDecompression::~MeshDecompression()
+{
+    if (mpImpl)
+    {
+        delete mpImpl;
+    }
+    mpImpl = nullptr;
+}
+
+MeshDecompression::eStatus MeshDecompression::Run(const char* pCompressedData,
+                                                  const size_t compressedDataSizeInBytes)
+{
+    return mpImpl->Run(pCompressedData, compressedDataSizeInBytes);
+}
+
+void MeshDecompression::GetMesh(float* pVertices,
+                                const size_t vertexStride,
+                                unsigned int* pIndices,
+                                unsigned char* pVisibilityAttributes) const
+{
+    if (mpImpl->mStatus.ok())
+    {
+        mpImpl->GetMesh(pVertices,
+                        vertexStride,
+                        pIndices,
+                        pVisibilityAttributes);
+    }
+}
+
+size_t MeshDecompression::GetVerticesCount() const
+{
+    if (mpImpl->mStatus.ok())
+    {
+        return static_cast<size_t>(mpImpl->mpMesh->num_points());
+    }
+    return 0;
+}
+
+size_t MeshDecompression::GetFacesCount() const
+{
+    if (mpImpl->mStatus.ok())
+    {
+        return static_cast<size_t>(mpImpl->mpMesh->num_faces());
+    }
+    return 0;
+}
+
+const char* MeshDecompression::GetLastErrorMessage() const
+{
+    return mpImpl->mStatus.error_msg();
+}
+
+}; // namespace draco
+}; // namespace psy

--- a/src/draco/psy/psy_draco_decoder.h
+++ b/src/draco/psy/psy_draco_decoder.h
@@ -1,0 +1,58 @@
+/*
+* @file psy_draco_decoder.h
+*
+* Copyright (c) 2017 Personify Inc.
+*
+* @brief
+*   Interface to mesh decompression
+*/
+
+#ifndef PSY_DRACO_MESH_DECOMPRESSION_H
+#define PSY_DRACO_MESH_DECOMPRESSION_H
+
+#include <memory>
+#include "psy_draco.h"
+
+namespace psy
+{
+namespace draco
+{
+
+/* A simple wrapper for draco decoder */
+class PSY_DRACO_API MeshDecompression
+{
+public:
+    enum eStatus
+    {
+        SUCCEED = 0,
+        FAILED
+    };
+
+    MeshDecompression();
+    ~MeshDecompression();
+
+    eStatus Run(const char* pCompressedData,
+                const size_t compressedDataSizeInBytes);
+
+    size_t GetVerticesCount() const;
+    size_t GetFacesCount() const;
+    void GetMesh(float* pVertices,
+                 const size_t vertexStride,
+                 unsigned int* pIndices,
+                 unsigned char* pVisibilityAttributes) const;
+
+    const char* GetLastErrorMessage() const;
+
+private:
+    /* MeshCompression is non-copyable */
+    MeshDecompression(const MeshDecompression&) {};
+    MeshDecompression& operator=(const MeshDecompression&) { return *this; };
+
+    class Impl;
+    Impl* mpImpl;
+}; // MeshCompression
+
+}; // namespace draco
+}; // namespace psy
+
+#endif // PSY_DRACO_MESH_DECOMPRESSION_H

--- a/src/draco/psy/psy_draco_encoder.cpp
+++ b/src/draco/psy/psy_draco_encoder.cpp
@@ -1,0 +1,221 @@
+/*
+* @file MeshCompression.cpp
+*
+* Copyright (c) 2016 Personify Inc.
+*
+* @brief
+*   Implements mesh MeshCompression
+*/
+
+#include "psy_draco_encoder.h"
+#include "draco/compression/encode.h"
+#include "draco/attributes/point_attribute.h"
+
+namespace psy
+{
+namespace draco
+{
+
+static const int MAX_COMPRESSION_LEVEL = 10;
+
+class MeshCompression::Impl
+{
+public:
+    Impl(int compressionLevel,
+         int vertexPositionQuantizationBitsCount,
+         bool hasVisibilityInfo) :
+        mCompressionLevel(compressionLevel),
+        mVertexPositionQuantizationBitsCount(vertexPositionQuantizationBitsCount),
+        mHasVisibilityInfo(hasVisibilityInfo),
+        mPositionAttributeId(0),
+        mVisibilityAttributeId(-1)
+    {
+        mCompressionLevel = std::max(0, std::min(MAX_COMPRESSION_LEVEL, mCompressionLevel));
+        mVertexPositionQuantizationBitsCount = std::max(0, mVertexPositionQuantizationBitsCount);
+
+        mpMesh.reset(new ::draco::Mesh());
+        mpBuffer.reset(new ::draco::EncoderBuffer());
+
+        mpEncoder.reset(new ::draco::Encoder());
+        {
+            mpEncoder->SetAttributeQuantization(
+                ::draco::GeometryAttribute::POSITION, mVertexPositionQuantizationBitsCount);
+            // Convert compression level to speed (that 0 = slowest, 10 = fastest).
+            const int speed = MAX_COMPRESSION_LEVEL - mCompressionLevel;
+            mpEncoder->SetSpeedOptions(speed, speed);
+
+            ::draco::GeometryAttribute pos_attrib;
+            pos_attrib.Init(::draco::GeometryAttribute::POSITION, nullptr, 3, ::draco::DT_FLOAT32, false, sizeof(float) * 3, 0);
+            mPositionAttributeId = mpMesh->AddAttribute(pos_attrib, true, 0);
+
+            if (mHasVisibilityInfo)
+            {
+                ::draco::GeometryAttribute vis_attrib;
+                vis_attrib.Init(::draco::GeometryAttribute::GENERIC, nullptr, 1, ::draco::DT_UINT8, false, sizeof(uint8_t), 0);
+                mVisibilityAttributeId = mpMesh->AddAttribute(vis_attrib, true, 0);
+            }
+        }
+    }
+
+    ~Impl()
+    {
+        mpMesh.reset();
+        mpBuffer.reset();
+        mpEncoder.reset();
+    }
+
+    void UpdateGeometryAttributeValues(const uint8_t* pValues,
+                                       const size_t stride,
+                                       const size_t verticesCount,
+                                       ::draco::PointAttribute* pPointAttribute)
+    {
+        pPointAttribute->SetIdentityMapping();
+        pPointAttribute->Resize(verticesCount);
+        pPointAttribute->Reset(verticesCount);
+        const size_t data_sz_in_bytes = pPointAttribute->byte_stride();
+        const auto dst_stride = pPointAttribute->byte_stride();
+        uint8_t* p_dst = pPointAttribute->buffer()->data();
+        if (stride == dst_stride)
+        {
+            memcpy(p_dst, pValues, verticesCount * data_sz_in_bytes);
+        }
+        else
+        {
+            for (size_t i = 0, src_idx = 0, dst_idx = 0;
+                i < verticesCount; ++i, pValues += stride, p_dst += dst_stride)
+            {
+                memcpy(p_dst, pValues, data_sz_in_bytes);
+            }
+        }
+    }
+
+    MeshCompression::eStatus Run(const float* pVertices,
+                                 const size_t vertexStride,
+                                 const size_t verticesCount,
+                                 const unsigned int* pIndices,
+                                 const size_t indicesCount,
+                                 const unsigned char* pVisibilityAttributes)
+    {
+        // reset encode buffer
+        mpBuffer->Resize(0);
+
+        // update faces
+        {
+            const size_t faces_count = indicesCount / 3;
+            {
+                // - we can using SetFace() to update a face at an index,
+                //   however, each call will have a check valid index inside the implementation
+                // - instead of, I'm doing an allocation memory first and then push data onto
+                mpMesh->SetNumFaces(faces_count); // allocation purpose
+                mpMesh->SetNumFaces(0);
+            }
+            ::draco::Mesh::Face face;
+            for (size_t i = 0, j = 0; i < faces_count; i++)
+            {
+                face[0] = static_cast<int32_t>(pIndices[j++]);
+                face[1] = static_cast<int32_t>(pIndices[j++]);
+                face[2] = static_cast<int32_t>(pIndices[j++]);
+                mpMesh->AddFace(face);
+            }
+        }
+
+        // update point attributes
+        {
+            mpMesh->set_num_points(static_cast<int32_t>(verticesCount));
+
+            // vertex positions
+            UpdateGeometryAttributeValues(reinterpret_cast<const uint8_t*>(pVertices),
+                                          vertexStride,
+                                          verticesCount,
+                                          mpMesh->attribute(mPositionAttributeId));
+
+            // update visibility info
+            if (mVisibilityAttributeId >= 0)
+            {
+                assert(nullptr != pVisibilityAttributes);
+                UpdateGeometryAttributeValues(pVisibilityAttributes,
+                                              sizeof(uint8_t),
+                                              verticesCount,
+                                              mpMesh->attribute(mVisibilityAttributeId));
+            }
+        }
+
+        // run compression
+        mStatus = mpEncoder->EncodeMeshToBuffer(*mpMesh, mpBuffer.get());
+        if (!mStatus.ok())
+        {
+            return eStatus::FAILED;
+        }
+
+        return eStatus::SUCCEED;
+    }
+
+    int mCompressionLevel;
+    int mVertexPositionQuantizationBitsCount;
+    bool mHasVisibilityInfo;
+
+    int mPositionAttributeId;
+    int mVisibilityAttributeId;
+
+    std::unique_ptr<::draco::Mesh> mpMesh;
+    std::unique_ptr<::draco::EncoderBuffer> mpBuffer;
+    std::unique_ptr<::draco::Encoder> mpEncoder;
+    ::draco::Status mStatus;
+};
+
+MeshCompression::MeshCompression(int compressionLevel,
+                                 int vertexPositionQuantizationBitsCount,
+                                 bool hasVisibilityInfo)
+{
+    mpImpl = new Impl(compressionLevel, vertexPositionQuantizationBitsCount, hasVisibilityInfo);
+}
+
+MeshCompression::~MeshCompression()
+{
+    if (mpImpl)
+    {
+        delete mpImpl;
+    }
+    mpImpl = nullptr;
+}
+
+MeshCompression::eStatus MeshCompression::Run(const float* pVertices,
+                                              const size_t vertexStride,
+                                              const size_t verticesCount,
+                                              const unsigned int* pIndices,
+                                              const size_t indicesCount,
+                                              const unsigned char* pVisibilityAttributes)
+{
+    return mpImpl->Run(pVertices,
+                       vertexStride,
+                       verticesCount,
+                       pIndices,
+                       indicesCount,
+                       pVisibilityAttributes);
+}
+
+const char* MeshCompression::GetCompressedData() const
+{
+    if (mpImpl->mStatus.ok())
+    {
+        return mpImpl->mpBuffer->data();
+    }
+    return nullptr;
+}
+
+size_t MeshCompression::GetCompressedDataSizeInBytes() const
+{
+    if (mpImpl->mStatus.ok())
+    {
+        return mpImpl->mpBuffer->size();
+    }
+    return 0;
+}
+
+const char* MeshCompression::GetLastErrorMessage() const
+{
+    return mpImpl->mStatus.error_msg();
+}
+
+}; // namespace draco
+}; // namespace psy

--- a/src/draco/psy/psy_draco_encoder.h
+++ b/src/draco/psy/psy_draco_encoder.h
@@ -1,0 +1,71 @@
+/*
+* @file psy_draco_encoder.h
+*
+* Copyright (c) 2017 Personify Inc.
+*
+* @brief
+*   Interface to mesh compression
+*/
+
+#ifndef PSY_DRACO_MESH_COMPRESSION_H
+#define PSY_DRACO_MESH_COMPRESSION_H
+
+#include <memory>
+#include "psy_draco.h"
+
+namespace psy
+{
+namespace draco
+{
+
+/* A simple wrapper for draco encoder */
+class PSY_DRACO_API MeshCompression
+{
+public:
+    enum eStatus
+    {
+        SUCCEED = 0,
+        FAILED
+    };
+    
+    /*
+    * - compressionLevel (compression level)
+    *   + {0 = lowest, 10 = highest} compression ratio.
+    * - vertexPositionQuantizationBitsCount (quantization parameter)
+    *   + 0: not perform any quantization
+    *   + ?: quantize the input values to that specified number of bits
+    * - hasVisibilityInfo (compress visibility info of view ports per camers
+    *   + determine existing visibility info to compress or not
+    *   + supporting maximum 8 view ports, have been presented by corresponding bits
+    *     1 for visible and 0 for invisible
+    */
+    MeshCompression(int compressionLevel = 7,
+                    int vertexPositionQuantizationBitsCount = 10,
+                    bool hasVisibilityInfo = false);
+    ~MeshCompression();
+
+    eStatus Run(const float* pVertices,
+                const size_t vertexStride,
+                const size_t verticesCount,
+                const unsigned int* pIndices,
+                const size_t indicesCount,
+                const unsigned char* pVisibilityAttributes);
+
+    const char* GetCompressedData() const;
+    size_t GetCompressedDataSizeInBytes() const;
+
+    const char* GetLastErrorMessage() const;
+
+private:
+    /* MeshCompression is non-copyable */
+    MeshCompression(const MeshCompression&) {};
+    MeshCompression& operator=(const MeshCompression&) { return *this; };
+
+    class Impl;
+    Impl* mpImpl;
+}; // MeshCompression
+
+}; // namespace draco
+}; // namespace psy
+
+#endif // PSY_DRACO_MESH_COMPRESSION_H


### PR DESCRIPTION
//cc @svensht2 
- These wrappers need for our using draco compression scheme(s) from visual studio 2013 projects.
- I think that we should keep this branch is the base branch for further work of draco integrations, so we do not need to merge it onto the master.