### PR TITLE
Add psy profiler sections and speedup compression and decompression for visibility info

### DIFF
--- a/src/draco/compression/attributes/attributes_encoder.h
+++ b/src/draco/compression/attributes/attributes_encoder.h
@@ -18,6 +18,7 @@
 #include "draco/attributes/point_attribute.h"
 #include "draco/core/encoder_buffer.h"
 #include "draco/point_cloud/point_cloud.h"
+#include "draco/psy/psy_draco.h"
 
 namespace draco {
 
@@ -48,15 +49,24 @@ class AttributesEncoder {
 
   // Encode attribute data to the target buffer.
   virtual bool EncodeAttributes(EncoderBuffer *out_buffer) {
-    if (!TransformAttributesToPortableFormat())
-      return false;
-    if (!EncodePortableAttributes(out_buffer))
-      return false;
+    {
+      PSY_DRACO_PROFILE_SECTION("TransformAttributesToPortableFormat");
+      if (!TransformAttributesToPortableFormat())
+        return false;
+    }
+    {
+      PSY_DRACO_PROFILE_SECTION("EncodePortableAttributes");
+      if (!EncodePortableAttributes(out_buffer))
+        return false;
+    }
     // Encode data needed by portable transforms after the attribute is encoded.
     // This corresponds to the order in which the data is going to be decoded by
     // the decoder.
-    if (!EncodeDataNeededByPortableTransforms(out_buffer))
-      return false;
+    {
+      PSY_DRACO_PROFILE_SECTION("EncodeDataNeededByPortableTransforms");
+      if (!EncodeDataNeededByPortableTransforms(out_buffer))
+        return false;
+    }
     return true;
   }
 

--- a/src/draco/compression/attributes/prediction_schemes/mesh_prediction_scheme_parallelogram_decoder.h
+++ b/src/draco/compression/attributes/prediction_schemes/mesh_prediction_scheme_parallelogram_decoder.h
@@ -17,6 +17,7 @@
 
 #include "draco/compression/attributes/prediction_schemes/mesh_prediction_scheme_decoder.h"
 #include "draco/compression/attributes/prediction_schemes/mesh_prediction_scheme_parallelogram_shared.h"
+#include "draco/psy/psy_draco.h"
 
 namespace draco {
 
@@ -58,6 +59,7 @@ bool MeshPredictionSchemeParallelogramDecoder<DataTypeT, TransformT,
     ComputeOriginalValues(const CorrType *in_corr, DataTypeT *out_data,
                           int /* size */, int num_components,
                           const PointIndex * /* entry_to_point_id_map */) {
+  PSY_DRACO_PROFILE_SECTION("ParallelogramDecoder::ComputeOriginalValues");
   this->transform().Initialize(num_components);
 
   const CornerTable *const table = this->mesh_data().corner_table();

--- a/src/draco/compression/attributes/prediction_schemes/mesh_prediction_scheme_parallelogram_encoder.h
+++ b/src/draco/compression/attributes/prediction_schemes/mesh_prediction_scheme_parallelogram_encoder.h
@@ -17,6 +17,7 @@
 
 #include "draco/compression/attributes/prediction_schemes/mesh_prediction_scheme_encoder.h"
 #include "draco/compression/attributes/prediction_schemes/mesh_prediction_scheme_parallelogram_shared.h"
+#include "draco/psy/psy_draco.h"
 
 namespace draco {
 
@@ -69,6 +70,7 @@ bool MeshPredictionSchemeParallelogramEncoder<DataTypeT, TransformT,
     ComputeCorrectionValues(const DataTypeT *in_data, CorrType *out_corr,
                             int size, int num_components,
                             const PointIndex * /* entry_to_point_id_map */) {
+  PSY_DRACO_PROFILE_SECTION("ParallelogramEncoder::ComputeCorrectionValues");
   this->transform().Initialize(in_data, size, num_components);
   std::unique_ptr<DataTypeT[]> pred_vals(new DataTypeT[num_components]());
 

--- a/src/draco/compression/attributes/sequential_attribute_encoder.cc
+++ b/src/draco/compression/attributes/sequential_attribute_encoder.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 //
 #include "draco/compression/attributes/sequential_attribute_encoder.h"
+#include "draco/psy/psy_draco.h"
 
 namespace draco {
 
@@ -45,6 +46,7 @@ bool SequentialAttributeEncoder::TransformAttributeToPortableFormat(
 
 bool SequentialAttributeEncoder::EncodePortableAttribute(
     const std::vector<PointIndex> &point_ids, EncoderBuffer *out_buffer) {
+  PSY_DRACO_PROFILE_SECTION("EncodePortableAttribute::EncodeValues (Lossless)");
   // Lossless encoding of the input values.
   if (!EncodeValues(point_ids, out_buffer))
     return false;
@@ -59,9 +61,11 @@ bool SequentialAttributeEncoder::EncodeDataNeededByPortableTransform(
 
 bool SequentialAttributeEncoder::EncodeValues(
     const std::vector<PointIndex> &point_ids, EncoderBuffer *out_buffer) {
+  PSY_DRACO_PROFILE_SECTION("EncodeValues (Raw format)");
   const int entry_size = attribute_->byte_stride();
   const std::unique_ptr<uint8_t[]> value_data_ptr(new uint8_t[entry_size]);
   uint8_t *const value_data = value_data_ptr.get();
+  // TODO[nbc]: check identity mapping first for speeding up?
   // Encode all attribute values in their native raw format.
   for (uint32_t i = 0; i < point_ids.size(); ++i) {
     const AttributeValueIndex entry_id = attribute_->mapped_index(point_ids[i]);

--- a/src/draco/compression/mesh/mesh_edgebreaker_decoder.cc
+++ b/src/draco/compression/mesh/mesh_edgebreaker_decoder.cc
@@ -17,6 +17,8 @@
 #include "draco/compression/mesh/mesh_edgebreaker_traversal_predictive_decoder.h"
 #include "draco/compression/mesh/mesh_edgebreaker_traversal_valence_decoder.h"
 
+#include "draco/psy/psy_draco.h"
+
 namespace draco {
 
 MeshEdgeBreakerDecoder::MeshEdgeBreakerDecoder() {}
@@ -26,6 +28,9 @@ bool MeshEdgeBreakerDecoder::CreateAttributesDecoder(int32_t att_decoder_id) {
 }
 
 bool MeshEdgeBreakerDecoder::InitializeDecoder() {
+
+  PSY_DRACO_PROFILE_SECTION("MeshEdgeBreakerEncoder::InitializeDecoder");
+
   uint8_t traversal_decoder_type;
   if (!buffer()->Decode(&traversal_decoder_type))
     return false;
@@ -59,6 +64,7 @@ bool MeshEdgeBreakerDecoder::DecodeConnectivity() {
 }
 
 bool MeshEdgeBreakerDecoder::OnAttributesDecoded() {
+  PSY_DRACO_PROFILE_SECTION("MeshEdgeBreakerEncoder::InitializeDecoder");
   return impl_->OnAttributesDecoded();
 }
 

--- a/src/draco/compression/mesh/mesh_edgebreaker_traversal_valence_encoder.h
+++ b/src/draco/compression/mesh/mesh_edgebreaker_traversal_valence_encoder.h
@@ -19,6 +19,8 @@
 #include "draco/core/symbol_encoding.h"
 #include "draco/core/varint_encoding.h"
 
+#include "draco/psy/psy_draco.h"
+
 namespace draco {
 
 // Predictive encoder for the Edgebreaker symbols based on valences of the
@@ -43,6 +45,10 @@ class MeshEdgeBreakerTraversalValenceEncoder
         max_valence_(7) {}
 
   bool Init(MeshEdgeBreakerEncoderImplInterface *encoder) {
+
+    // psy_draco.h
+    PSY_DRACO_PROFILE_SECTION("MeshEdgeBreakerEncoderImplInterface::Init");
+
     if (!MeshEdgeBreakerTraversalEncoder::Init(encoder))
       return false;
     min_valence_ = 2;

--- a/src/draco/compression/mesh/mesh_encoder.cc
+++ b/src/draco/compression/mesh/mesh_encoder.cc
@@ -13,7 +13,6 @@
 // limitations under the License.
 //
 #include "draco/compression/mesh/mesh_encoder.h"
-
 namespace draco {
 
 MeshEncoder::MeshEncoder() : mesh_(nullptr) {}

--- a/src/draco/compression/point_cloud/point_cloud_decoder.cc
+++ b/src/draco/compression/point_cloud/point_cloud_decoder.cc
@@ -16,6 +16,8 @@
 
 #include "draco/metadata/metadata_decoder.h"
 
+#include "draco/psy/psy_draco.h"
+
 namespace draco {
 
 PointCloudDecoder::PointCloudDecoder()
@@ -96,6 +98,7 @@ Status PointCloudDecoder::Decode(const DecoderOptions &options,
 }
 
 bool PointCloudDecoder::DecodePointAttributes() {
+  PSY_DRACO_PROFILE_SECTION("DecodePointAttributes");
   uint8_t num_attributes_decoders;
   if (!buffer_->Decode(&num_attributes_decoders))
     return false;

--- a/src/draco/compression/point_cloud/point_cloud_encoder.cc
+++ b/src/draco/compression/point_cloud/point_cloud_encoder.cc
@@ -16,6 +16,8 @@
 
 #include "draco/metadata/metadata_encoder.h"
 
+#include "draco/psy/psy_draco.h"
+
 namespace draco {
 
 PointCloudEncoder::PointCloudEncoder()
@@ -87,6 +89,8 @@ Status PointCloudEncoder::EncodeMetadata() {
 }
 
 bool PointCloudEncoder::EncodePointAttributes() {
+  PSY_DRACO_PROFILE_SECTION("EncodePointAttributes");
+
   if (!GenerateAttributesEncoders())
     return false;
 

--- a/src/draco/psy/psy_draco.h
+++ b/src/draco/psy/psy_draco.h
@@ -28,4 +28,31 @@
 #    endif
 #endif
 
+#include <memory>
+class PSY_DRACO_API IProfiler {};
+class PSY_DRACO_API IProfilerManager
+{
+public:
+    virtual std::shared_ptr<IProfiler> CreateProfilerSection(const char* pName) = 0;
+};
+
+namespace psy
+{
+    PSY_DRACO_API IProfilerManager* GetProfilerManager();
+    PSY_DRACO_API void SetProfilerManager(IProfilerManager*);
+}; // namespace psy
+
+#ifndef PSY_DRACO_PROFILE_ENABLE
+#define PSY_DRACO_PROFILE_ENABLE 1
+#endif
+
+#if PSY_DRACO_PROFILE_ENABLE
+    #define PSY_DRACO_PROFILE_SECTION(name) \
+        IProfilerManager* prof_manager = psy::GetProfilerManager(); \
+        std::shared_ptr<IProfiler> psy_draco_prof_section = \
+            ((prof_manager) ? (prof_manager->CreateProfilerSection(name)) : (nullptr));
+#else
+    #define PSY_DRACO_PROFILE_SECTION(name)
+#endif // PSY_DRACO_PROFILE_ENABLE
+
 #endif // PSY_DRACO_COMMON_H

--- a/src/draco/psy/psy_draco_encoder.cpp
+++ b/src/draco/psy/psy_draco_encoder.cpp
@@ -13,6 +13,21 @@
 
 namespace psy
 {
+
+static IProfilerManager* gmpProfilerManager = nullptr;
+IProfilerManager* GetProfilerManager()
+{
+    return gmpProfilerManager;
+}
+void SetProfilerManager(IProfilerManager* pProp)
+{
+    if (gmpProfilerManager)
+    {
+        delete gmpProfilerManager;
+    }
+    gmpProfilerManager = pProp;
+}
+
 namespace draco
 {
 
@@ -96,11 +111,13 @@ public:
                                  const size_t indicesCount,
                                  const unsigned char* pVisibilityAttributes)
     {
+        PSY_DRACO_PROFILE_SECTION("MeshCompression::Impl::Run");
         // reset encode buffer
         mpBuffer->Resize(0);
 
         // update faces
         {
+            PSY_DRACO_PROFILE_SECTION("MeshCompression::Impl::Run (update faces)");
             const size_t faces_count = indicesCount / 3;
             {
                 // - we can using SetFace() to update a face at an index,
@@ -121,6 +138,7 @@ public:
 
         // update point attributes
         {
+            PSY_DRACO_PROFILE_SECTION("MeshCompression::Impl::Run (update attributes)");
             mpMesh->set_num_points(static_cast<int32_t>(verticesCount));
 
             // vertex positions
@@ -141,10 +159,13 @@ public:
         }
 
         // run compression
-        mStatus = mpEncoder->EncodeMeshToBuffer(*mpMesh, mpBuffer.get());
-        if (!mStatus.ok())
         {
-            return eStatus::FAILED;
+            PSY_DRACO_PROFILE_SECTION("MeshCompression::Impl::Run (EncodeMeshToBuffer)");
+            mStatus = mpEncoder->EncodeMeshToBuffer(*mpMesh, mpBuffer.get());
+            if (!mStatus.ok())
+            {
+                return eStatus::FAILED;
+            }
         }
 
         return eStatus::SUCCEED;


### PR DESCRIPTION
This PR is requesting to merge onto [personify-1.0](https://github.com/google/draco/compare/master...PersonifyInc:personify-1.0)
- add profiler sections
- enable split_mesh_on_seams option if possible. This helps to speed up both compression and decompression performance if there has more than 1 point geometry attribute. For our case, it's for adding visibility info to mesh compression

//cc @svensht2 