### PR TITLE
Support incremental mesh compression

### DIFF
--- a/src/draco/compression/mesh/mesh_edgebreaker_decoder.cc
+++ b/src/draco/compression/mesh/mesh_edgebreaker_decoder.cc
@@ -17,20 +17,34 @@
 #include "draco/compression/mesh/mesh_edgebreaker_traversal_predictive_decoder.h"
 #include "draco/compression/mesh/mesh_edgebreaker_traversal_valence_decoder.h"
 
-#include "draco/psy/psy_draco.h"
-
 namespace draco {
 
 MeshEdgeBreakerDecoder::MeshEdgeBreakerDecoder() {}
+
+std::unique_ptr<MeshEdgeBreakerDecoderImplInterface>
+MeshEdgeBreakerDecoder::CloneDecoderImplState() {
+  if (impl_) {
+    return impl_->Clone();
+  }
+  return nullptr;
+}
+
+void MeshEdgeBreakerDecoder::SetDecoderImplState(
+  MeshEdgeBreakerDecoderImplInterface& rDecoderState) {
+  if (impl_) {
+      impl_.reset();
+  }
+  impl_ = std::move(rDecoderState.Clone());
+  if (impl_) {
+    impl_->Init(this);
+  }
+}
 
 bool MeshEdgeBreakerDecoder::CreateAttributesDecoder(int32_t att_decoder_id) {
   return impl_->CreateAttributesDecoder(att_decoder_id);
 }
 
 bool MeshEdgeBreakerDecoder::InitializeDecoder() {
-
-  PSY_DRACO_PROFILE_SECTION("MeshEdgeBreakerEncoder::InitializeDecoder");
-
   uint8_t traversal_decoder_type;
   if (!buffer()->Decode(&traversal_decoder_type))
     return false;
@@ -64,7 +78,6 @@ bool MeshEdgeBreakerDecoder::DecodeConnectivity() {
 }
 
 bool MeshEdgeBreakerDecoder::OnAttributesDecoded() {
-  PSY_DRACO_PROFILE_SECTION("MeshEdgeBreakerEncoder::InitializeDecoder");
   return impl_->OnAttributesDecoded();
 }
 

--- a/src/draco/compression/mesh/mesh_edgebreaker_decoder.h
+++ b/src/draco/compression/mesh/mesh_edgebreaker_decoder.h
@@ -39,6 +39,9 @@ class MeshEdgeBreakerDecoder : public MeshDecoder {
     return impl_->GetAttributeEncodingData(att_id);
   }
 
+  std::unique_ptr<MeshEdgeBreakerDecoderImplInterface> CloneDecoderImplState();
+  void SetDecoderImplState(MeshEdgeBreakerDecoderImplInterface& rDecoderState);
+
  protected:
   bool InitializeDecoder() override;
   bool CreateAttributesDecoder(int32_t att_decoder_id) override;

--- a/src/draco/compression/mesh/mesh_edgebreaker_decoder_impl.cc
+++ b/src/draco/compression/mesh/mesh_edgebreaker_decoder_impl.cc
@@ -44,17 +44,53 @@ namespace draco {
 
 template <class TraversalDecoder>
 MeshEdgeBreakerDecoderImpl<TraversalDecoder>::MeshEdgeBreakerDecoderImpl()
-    : decoder_(nullptr),
-      last_symbol_id_(-1),
-      last_vert_id_(-1),
-      last_face_id_(-1),
-      num_new_vertices_(0),
-      num_encoded_vertices_(0) {}
+  : decoder_(nullptr),
+    last_symbol_id_(-1),
+    last_vert_id_(-1),
+    last_face_id_(-1),
+    num_new_vertices_(0),
+    num_encoded_vertices_(0) {}
+
+template <class TraversalDecoder>
+std::unique_ptr<MeshEdgeBreakerDecoderImplInterface>
+MeshEdgeBreakerDecoderImpl<TraversalDecoder>::Clone()
+{
+  auto impl = std::unique_ptr<MeshEdgeBreakerDecoderImplInterface>(
+        new MeshEdgeBreakerDecoderImpl<TraversalDecoder>());
+  auto ptr = (MeshEdgeBreakerDecoderImpl<TraversalDecoder>*)impl.get();
+  ptr->decoder_ = decoder_;
+  ptr->corner_table_ = std::move(corner_table_->Clone());
+  ptr->corner_traversal_stack_ = corner_traversal_stack_;
+  ptr->vertex_traversal_length_ = vertex_traversal_length_;
+  ptr->topology_split_data_ = topology_split_data_;
+  ptr->hole_event_data_ = hole_event_data_;
+  ptr->init_face_configurations_ = init_face_configurations_;
+  ptr->init_corners_ = init_corners_;
+  ptr->vertex_id_map_ = vertex_id_map_;
+  ptr->last_symbol_id_ = last_symbol_id_;
+  ptr->last_vert_id_ = last_vert_id_;
+  ptr->last_face_id_ = last_face_id_;
+  ptr->visited_faces_ = visited_faces_;
+  ptr->visited_verts_ = visited_verts_;
+  ptr->is_vert_hole_ = is_vert_hole_;
+  ptr->num_new_vertices_ = num_new_vertices_;
+  ptr->new_to_parent_vertex_map_ = new_to_parent_vertex_map_;
+  ptr->num_encoded_vertices_ = num_encoded_vertices_;
+  ptr->processed_corner_ids_ = processed_corner_ids_;
+  ptr->processed_connectivity_corners_ = processed_connectivity_corners_;
+  ptr->pos_encoding_data_ = pos_encoding_data_;
+  ptr->attribute_data_ = attribute_data_;
+  traversal_decoder_.CopyTo(ptr->traversal_decoder_);
+  return std::move(impl);
+}
 
 template <class TraversalDecoder>
 bool MeshEdgeBreakerDecoderImpl<TraversalDecoder>::Init(
     MeshEdgeBreakerDecoder *decoder) {
   decoder_ = decoder;
+  if (decoder->GetCornerTable()) {
+    traversal_decoder_.Init(this);
+  }
   return true;
 }
 

--- a/src/draco/compression/mesh/mesh_edgebreaker_decoder_impl.h
+++ b/src/draco/compression/mesh/mesh_edgebreaker_decoder_impl.h
@@ -66,6 +66,8 @@ class MeshEdgeBreakerDecoderImpl : public MeshEdgeBreakerDecoderImplInterface {
     return corner_table_.get();
   }
 
+  std::unique_ptr<MeshEdgeBreakerDecoderImplInterface> Clone() override;
+
  private:
   // Creates a vertex traversal sequencer for the specified |TraverserT| type.
   template <class TraverserT>

--- a/src/draco/compression/mesh/mesh_edgebreaker_decoder_impl_interface.h
+++ b/src/draco/compression/mesh/mesh_edgebreaker_decoder_impl_interface.h
@@ -40,6 +40,8 @@ class MeshEdgeBreakerDecoderImplInterface {
 
   virtual MeshEdgeBreakerDecoder *GetDecoder() const = 0;
   virtual const CornerTable *GetCornerTable() const = 0;
+
+  virtual std::unique_ptr<MeshEdgeBreakerDecoderImplInterface> Clone() = 0;
 };
 
 }  // namespace draco

--- a/src/draco/compression/mesh/mesh_edgebreaker_encoder.cc
+++ b/src/draco/compression/mesh/mesh_edgebreaker_encoder.cc
@@ -22,6 +22,25 @@ namespace draco {
 
 MeshEdgeBreakerEncoder::MeshEdgeBreakerEncoder() {}
 
+std::unique_ptr<MeshEdgeBreakerEncoderImplInterface>
+MeshEdgeBreakerEncoder::CloneEncoderImplState() {
+  if (impl_) {
+    return impl_->Clone();
+  }
+  return nullptr;
+}
+
+void MeshEdgeBreakerEncoder::SetEncoderImplState(
+  MeshEdgeBreakerEncoderImplInterface& rEncoderState) {
+  if (impl_) {
+      impl_.reset();
+  }
+  impl_ = std::move(rEncoderState.Clone());
+  if (impl_) {
+    impl_->Init(this);
+  }
+}
+
 bool MeshEdgeBreakerEncoder::InitializeEncoder() {
   const bool is_standard_edgebreaker_avaialable =
       options()->IsFeatureSupported(features::kEdgebreaker);

--- a/src/draco/compression/mesh/mesh_edgebreaker_encoder.h
+++ b/src/draco/compression/mesh/mesh_edgebreaker_encoder.h
@@ -49,6 +49,9 @@ class MeshEdgeBreakerEncoder : public MeshEncoder {
     return MESH_EDGEBREAKER_ENCODING;
   }
 
+  std::unique_ptr<MeshEdgeBreakerEncoderImplInterface> CloneEncoderImplState();
+  void SetEncoderImplState(MeshEdgeBreakerEncoderImplInterface& rEncoderState);
+
  protected:
   bool InitializeEncoder() override;
   bool EncodeConnectivity() override;

--- a/src/draco/compression/mesh/mesh_edgebreaker_encoder_impl.cc
+++ b/src/draco/compression/mesh/mesh_edgebreaker_encoder_impl.cc
@@ -44,11 +44,44 @@ MeshEdgeBreakerEncoderImpl<TraversalEncoder>::MeshEdgeBreakerEncoderImpl()
       use_single_connectivity_(false) {}
 
 template <class TraversalEncoder>
+std::unique_ptr<MeshEdgeBreakerEncoderImplInterface>
+MeshEdgeBreakerEncoderImpl<TraversalEncoder>::Clone()
+{
+  auto impl = std::unique_ptr<MeshEdgeBreakerEncoderImplInterface>(
+        new MeshEdgeBreakerEncoderImpl<TraversalEncoder>());
+  auto ptr = (MeshEdgeBreakerEncoderImpl<TraversalEncoder>*)impl.get();
+  ptr->encoder_ = encoder_;
+  ptr->mesh_ = mesh_;
+  ptr->corner_table_ = std::move(corner_table_->Clone());
+  ptr->corner_traversal_stack_ = corner_traversal_stack_;
+  ptr->visited_faces_ = visited_faces_;
+  ptr->pos_encoding_data_ = pos_encoding_data_;
+  ptr->pos_traversal_method_ = pos_traversal_method_;
+  ptr->processed_connectivity_corners_ = processed_connectivity_corners_;
+  ptr->visited_vertex_ids_ = visited_vertex_ids_;
+  ptr->vertex_traversal_length_ = vertex_traversal_length_;
+  ptr->topology_split_event_data_ = topology_split_event_data_;
+  ptr->face_to_split_symbol_map_ = face_to_split_symbol_map_;
+  ptr->visited_holes_ = visited_holes_;
+  ptr->vertex_hole_id_ = vertex_hole_id_;
+  ptr->last_encoded_symbol_id_ = last_encoded_symbol_id_;
+  ptr->num_split_symbols_ = num_split_symbols_;
+  ptr->attribute_data_ = attribute_data_;
+  ptr->attribute_encoder_to_data_id_map_ = attribute_encoder_to_data_id_map_;
+  traversal_encoder_.CopyTo(ptr->traversal_encoder_);
+  ptr->use_single_connectivity_ = use_single_connectivity_;
+  return std::move(impl);
+}
+
+template <class TraversalEncoder>
 bool MeshEdgeBreakerEncoderImpl<TraversalEncoder>::Init(
     MeshEdgeBreakerEncoder *encoder) {
   encoder_ = encoder;
   mesh_ = encoder->mesh();
   attribute_encoder_to_data_id_map_.clear();
+  if (encoder->GetCornerTable()) {
+    traversal_encoder_.Init(this);
+  }
 
   if (encoder_->options()->IsGlobalOptionSet("split_mesh_on_seams")) {
     use_single_connectivity_ =

--- a/src/draco/compression/mesh/mesh_edgebreaker_encoder_impl.h
+++ b/src/draco/compression/mesh/mesh_edgebreaker_encoder_impl.h
@@ -54,6 +54,8 @@ class MeshEdgeBreakerEncoderImpl : public MeshEdgeBreakerEncoderImplInterface {
   }
   MeshEdgeBreakerEncoder *GetEncoder() const override { return encoder_; }
 
+  std::unique_ptr<MeshEdgeBreakerEncoderImplInterface> Clone() override;
+
  private:
   // Initializes data needed for encoding non-position attributes.
   // Returns false on error.

--- a/src/draco/compression/mesh/mesh_edgebreaker_encoder_impl_interface.h
+++ b/src/draco/compression/mesh/mesh_edgebreaker_encoder_impl_interface.h
@@ -50,6 +50,8 @@ class MeshEdgeBreakerEncoderImplInterface {
   virtual bool IsFaceEncoded(FaceIndex fi) const = 0;
 
   virtual MeshEdgeBreakerEncoder *GetEncoder() const = 0;
+
+  virtual std::unique_ptr<MeshEdgeBreakerEncoderImplInterface> Clone() = 0;
 };
 
 }  // namespace draco

--- a/src/draco/compression/mesh/mesh_edgebreaker_traversal_decoder.h
+++ b/src/draco/compression/mesh/mesh_edgebreaker_traversal_decoder.h
@@ -121,6 +121,29 @@ class MeshEdgeBreakerTraversalDecoder {
     }
   }
 
+  void CopyTo(MeshEdgeBreakerTraversalDecoder& rOther) {
+    rOther.buffer_ = buffer_;
+    rOther.symbol_buffer_ = symbol_buffer_;
+    rOther.start_face_decoder_ = start_face_decoder_;
+    rOther.start_face_buffer_ = start_face_buffer_;
+    rOther.num_attribute_data_ = num_attribute_data_;
+    if (num_attribute_data_ > 0) {
+      rOther.attribute_connectivity_decoders_ = std::unique_ptr<BinaryDecoder[]>(
+        new BinaryDecoder[num_attribute_data_]);
+      for (int i = 0; i < num_attribute_data_; ++i) {
+        rOther.attribute_connectivity_decoders_[i] = attribute_connectivity_decoders_[i];
+      }
+    }
+    rOther.decoder_impl_ = decoder_impl_;
+  }
+
+  std::unique_ptr<MeshEdgeBreakerTraversalDecoder> Clone() {
+    auto ret = std::unique_ptr<MeshEdgeBreakerTraversalDecoder>(
+        new MeshEdgeBreakerTraversalDecoder());
+    CopyTo(*ret);
+    return std::move(ret);
+  }
+
  protected:
   DecoderBuffer *buffer() { return &buffer_; }
 

--- a/src/draco/compression/mesh/mesh_edgebreaker_traversal_encoder.h
+++ b/src/draco/compression/mesh/mesh_edgebreaker_traversal_encoder.h
@@ -91,6 +91,28 @@ class MeshEdgeBreakerTraversalEncoder {
 
   const EncoderBuffer &buffer() const { return traversal_buffer_; }
 
+  void CopyTo(MeshEdgeBreakerTraversalEncoder& rOther) {
+    rOther.start_face_encoder_ = start_face_encoder_;
+    traversal_buffer_.CopyTo(rOther.traversal_buffer_);
+    rOther.encoder_impl_ = encoder_impl_;
+    rOther.symbols_ = symbols_;
+    rOther.num_attribute_data_ = num_attribute_data_;
+    if (num_attribute_data_ > 0) {
+      rOther.attribute_connectivity_encoders_ = std::unique_ptr<BinaryEncoder[]>(
+        new BinaryEncoder[num_attribute_data_]);
+      for (int i = 0; i < num_attribute_data_; ++i) {
+        rOther.attribute_connectivity_encoders_[i] = attribute_connectivity_encoders_[i];
+      }
+    }
+  }
+
+  std::unique_ptr<MeshEdgeBreakerTraversalEncoder> Clone() {
+    auto ret = std::unique_ptr<MeshEdgeBreakerTraversalEncoder>(
+        new MeshEdgeBreakerTraversalEncoder());
+    CopyTo(*ret);
+    return std::move(ret);
+  }
+
  protected:
   void EncodeTraversalSymbols() {
     // Bit encode the collected symbols.

--- a/src/draco/compression/mesh/mesh_edgebreaker_traversal_valence_decoder.h
+++ b/src/draco/compression/mesh/mesh_edgebreaker_traversal_valence_decoder.h
@@ -168,6 +168,26 @@ class MeshEdgeBreakerTraversalValenceDecoder
     vertex_valences_[dest] += vertex_valences_[source];
   }
 
+  void CopyTo(MeshEdgeBreakerTraversalValenceDecoder& rOther) {
+    MeshEdgeBreakerTraversalDecoder::CopyTo(*((MeshEdgeBreakerTraversalDecoder*)&rOther));
+    rOther.corner_table_ = corner_table_;
+    rOther.num_vertices_ = num_vertices_;
+    rOther.vertex_valences_ = vertex_valences_;
+    rOther.last_symbol_ = last_symbol_;
+    rOther.active_context_ = active_context_;
+    rOther.min_valence_ = min_valence_;
+    rOther.max_valence_ = max_valence_;
+    rOther.context_symbols_ = context_symbols_;
+    rOther.context_counters_ = context_counters_;
+  }
+
+  std::unique_ptr<MeshEdgeBreakerTraversalValenceDecoder> Clone() {
+    auto ret = std::unique_ptr<MeshEdgeBreakerTraversalValenceDecoder>(
+        new MeshEdgeBreakerTraversalValenceDecoder());
+    CopyTo(*ret);
+    return std::move(ret);
+  }
+
  private:
   const CornerTable *corner_table_;
   int num_vertices_;

--- a/src/draco/compression/mesh/mesh_edgebreaker_traversal_valence_encoder.h
+++ b/src/draco/compression/mesh/mesh_edgebreaker_traversal_valence_encoder.h
@@ -51,9 +51,13 @@ class MeshEdgeBreakerTraversalValenceEncoder
 
     if (!MeshEdgeBreakerTraversalEncoder::Init(encoder))
       return false;
+
+    corner_table_ = encoder->GetCornerTable();
+    if (vertex_valences_.size() == corner_table_->num_vertices()) {
+      return true;
+    }
     min_valence_ = 2;
     max_valence_ = 7;
-    corner_table_ = encoder->GetCornerTable();
 
     // Initialize valences of all vertices.
     vertex_valences_.resize(corner_table_->num_vertices());
@@ -202,6 +206,25 @@ class MeshEdgeBreakerTraversalValenceEncoder
   }
 
   int NumEncodedSymbols() const { return num_symbols_; }
+
+  void CopyTo(MeshEdgeBreakerTraversalValenceEncoder& rOther) {
+    MeshEdgeBreakerTraversalEncoder::CopyTo(*((MeshEdgeBreakerTraversalEncoder*)&rOther));
+    rOther.corner_table_ = corner_table_;
+    rOther.corner_to_vertex_map_ = corner_to_vertex_map_;
+    rOther.vertex_valences_ = vertex_valences_;
+    rOther.prev_symbol_ = prev_symbol_;
+    rOther.num_symbols_ = num_symbols_;
+    rOther.min_valence_ = min_valence_;
+    rOther.max_valence_ = max_valence_;
+    rOther.context_symbols_ = context_symbols_;
+  }
+
+  std::unique_ptr<MeshEdgeBreakerTraversalValenceEncoder> Clone() {
+    auto ret = std::unique_ptr<MeshEdgeBreakerTraversalValenceEncoder>(
+        new MeshEdgeBreakerTraversalValenceEncoder());
+    CopyTo(*ret);
+    return std::move(ret);
+  }
 
  private:
   const CornerTable *corner_table_;

--- a/src/draco/mesh/corner_table.h
+++ b/src/draco/mesh/corner_table.h
@@ -52,6 +52,12 @@ class CornerTable {
   static std::unique_ptr<CornerTable> Create(
       const IndexTypeVector<FaceIndex, FaceType> &faces);
 
+  std::unique_ptr<CornerTable> Clone() const {
+    auto corner_table = std::unique_ptr<CornerTable>(new CornerTable());
+    *corner_table = *this;
+    return std::move(corner_table);
+  }
+
   // Initializes the CornerTable from provides set of indexed faces.
   // The input faces can represent a non-manifold topology, in which case the
   // non-manifold edges and vertices are going to be split.

--- a/src/draco/psy/psy_draco.h
+++ b/src/draco/psy/psy_draco.h
@@ -34,12 +34,32 @@ class PSY_DRACO_API IProfilerManager
 {
 public:
     virtual std::shared_ptr<IProfiler> CreateProfilerSection(const char* pName) = 0;
+    virtual ~IProfilerManager() {}
 };
 
 namespace psy
 {
-    PSY_DRACO_API IProfilerManager* GetProfilerManager();
-    PSY_DRACO_API void SetProfilerManager(IProfilerManager*);
+
+PSY_DRACO_API IProfilerManager* GetProfilerManager();
+PSY_DRACO_API void SetProfilerManager(IProfilerManager*);
+
+namespace draco
+{
+
+enum PSY_DRACO_API MeshType : uint8_t
+{
+    FULL_MESH = 0,
+    INCREMENTAL_MESH = 1
+};
+
+struct PSY_DRACO_API Header
+{
+    uint8_t mMajorVersion;
+    uint8_t mMinorVersion;
+    MeshType mMeshType;
+};
+
+}; // namespace draco
 }; // namespace psy
 
 #ifndef PSY_DRACO_PROFILE_ENABLE

--- a/src/draco/psy/psy_draco_decoder.h
+++ b/src/draco/psy/psy_draco_decoder.h
@@ -34,6 +34,7 @@ public:
     eStatus Run(const char* pCompressedData,
                 const size_t compressedDataSizeInBytes);
 
+    const Header* GetDecompressedHeader() const;
     size_t GetVerticesCount() const;
     size_t GetFacesCount() const;
     void GetMesh(float* pVertices,

--- a/src/draco/psy/psy_draco_encoder.cpp
+++ b/src/draco/psy/psy_draco_encoder.cpp
@@ -8,17 +8,17 @@
 */
 
 #include "psy_draco_encoder.h"
-#include "draco/compression/encode.h"
+#include "draco/compression/config/encoder_options.h"
 #include "draco/attributes/point_attribute.h"
+#include "draco/compression/mesh/mesh_edgebreaker_encoder.h"
 
 namespace psy
 {
-
 static IProfilerManager* gmpProfilerManager = nullptr;
 IProfilerManager* GetProfilerManager()
 {
     return gmpProfilerManager;
-}
+} // GetProfilerManager
 void SetProfilerManager(IProfilerManager* pProp)
 {
     if (gmpProfilerManager)
@@ -26,12 +26,91 @@ void SetProfilerManager(IProfilerManager* pProp)
         delete gmpProfilerManager;
     }
     gmpProfilerManager = pProp;
-}
+} // SetProfilerManager
+} // namespace psy
 
+namespace psy
+{
 namespace draco
 {
 
 static const int MAX_COMPRESSION_LEVEL = 10;
+
+class CompressionOptions : public ::draco::DracoOptions<::draco::GeometryAttribute::Type>
+{
+public:
+    CompressionOptions()
+    {
+        mFeatureOptions.SetBool(::draco::features::kEdgebreaker, true);
+        mFeatureOptions.SetBool(::draco::features::kPredictiveEdgebreaker, true);
+    }
+
+    ::draco::EncoderOptions CreateEncoderOptions(const ::draco::Mesh &rMesh) const
+    {
+        auto options = ::draco::EncoderOptions::CreateEmptyOptions();
+        options.SetGlobalOptions(this->GetGlobalOptions());
+        options.SetFeatureOptions(mFeatureOptions);
+        for (int i = 0; i < rMesh.num_attributes(); ++i)
+        {
+            const auto* p_att_options =
+                this->FindAttributeOptions(rMesh.attribute(i)->attribute_type());
+            if (p_att_options)
+            {
+                options.SetAttributeOptions(i, *p_att_options);
+            }
+        }
+        return options;
+    }
+
+    // List of supported/unsupported features that can be used by the encoder.
+    ::draco::Options mFeatureOptions;
+}; // CompressionOptions
+
+class MeshEdgeBreakerCompression : protected ::draco::MeshEdgeBreakerEncoder
+{
+public:
+    MeshEdgeBreakerCompression() : ::draco::MeshEdgeBreakerEncoder()
+    {
+        mIsIncrementalCompression = false;
+    }
+
+    ::draco::Status Compress(const CompressionOptions& rCompressionOptions,
+                             const ::draco::Mesh& rMesh,
+                             ::draco::EncoderBuffer& rOutBuffer,
+                             const bool isIncrementalCompression)
+    {
+        mIsIncrementalCompression = isIncrementalCompression;
+        this->SetMesh(rMesh);
+        return Encode(rCompressionOptions.CreateEncoderOptions(rMesh), &rOutBuffer);
+    }
+protected:
+    bool InitializeEncoder() override
+    {
+        if (mIsIncrementalCompression)
+        {
+            SetEncoderImplState(*mpEncoderState);
+            return true;
+        }
+        return ::draco::MeshEdgeBreakerEncoder::InitializeEncoder();
+    }
+
+    bool EncodeConnectivity() override
+    {
+        if (mIsIncrementalCompression)
+        {
+            return true;
+        }
+        const auto status = ::draco::MeshEdgeBreakerEncoder::EncodeConnectivity();
+        if (status)
+        {
+            mpEncoderState = std::move(CloneEncoderImplState());
+        }
+        return status;
+    }
+private:
+    bool mIsIncrementalCompression;
+    std::unique_ptr<::draco::MeshEdgeBreakerEncoderImplInterface> mpEncoderState;
+}; // MeshEdgeBreakerCompression
 
 class MeshCompression::Impl
 {
@@ -50,7 +129,8 @@ public:
 
         mpMesh.reset(new ::draco::Mesh());
         mpBuffer.reset(new ::draco::EncoderBuffer());
-        mpEncoder.reset(new ::draco::Encoder());
+        mpCompressionOptions.reset(new CompressionOptions());
+        mpMeshCompression.reset(new MeshEdgeBreakerCompression());
         {
             int num_attribs = 1;
 
@@ -69,15 +149,14 @@ public:
                 num_attribs++;
             }
 
-            auto options = ::draco::EncoderOptionsBase<::draco::GeometryAttribute::Type>::CreateDefaultOptions();
-            options.SetAttributeInt(::draco::GeometryAttribute::POSITION,
-                                    "quantization_bits",
-                                    mVertexPositionQuantizationBitsCount);
+            mpCompressionOptions->SetAttributeInt(::draco::GeometryAttribute::POSITION,
+                                                  "quantization_bits",
+                                                  mVertexPositionQuantizationBitsCount);
             // Convert compression level to speed (that 0 = slowest, 10 = fastest).
             const int speed = MAX_COMPRESSION_LEVEL - mCompressionLevel;
-            options.SetSpeed(speed, speed);
-            options.SetGlobalBool("split_mesh_on_seams", (num_attribs > 1));
-            mpEncoder->Reset(options);
+            mpCompressionOptions->SetGlobalInt("encoding_speed", speed);
+            mpCompressionOptions->SetGlobalInt("decoding_speed", speed);
+            mpCompressionOptions->SetGlobalBool("split_mesh_on_seams", (num_attribs > 1));
         }
     }
 
@@ -85,7 +164,15 @@ public:
     {
         mpMesh.reset();
         mpBuffer.reset();
-        mpEncoder.reset();
+        mpMeshCompression.reset();
+    }
+
+    void SetVertexPositionQuantizationBitsCount(const int vertexPositionQuantizationBitsCount)
+    {
+        mVertexPositionQuantizationBitsCount = std::max(0, vertexPositionQuantizationBitsCount);
+        mpCompressionOptions->SetAttributeInt(::draco::GeometryAttribute::POSITION,
+                                              "quantization_bits",
+                                              mVertexPositionQuantizationBitsCount);
     }
 
     void UpdateGeometryAttributeValues(const uint8_t* pValues,
@@ -99,37 +186,52 @@ public:
         const size_t data_sz_in_bytes = pPointAttribute->byte_stride();
         const auto dst_stride = pPointAttribute->byte_stride();
         uint8_t* p_dst = pPointAttribute->buffer()->data();
-        if (stride == dst_stride)
+        if (stride == static_cast<size_t>(dst_stride))
         {
             memcpy(p_dst, pValues, verticesCount * data_sz_in_bytes);
         }
         else
         {
-            for (size_t i = 0, src_idx = 0, dst_idx = 0;
-                i < verticesCount; ++i, pValues += stride, p_dst += dst_stride)
+            for (size_t i = 0; i < verticesCount; ++i, pValues += stride, p_dst += dst_stride)
             {
                 memcpy(p_dst, pValues, data_sz_in_bytes);
             }
         }
-    }
+    } // UpdateGeometryAttributeValues
 
     MeshCompression::eStatus Run(const float* pVertices,
                                  const size_t vertexStride,
                                  const size_t verticesCount,
                                  const unsigned int* pIndices,
                                  const size_t indicesCount,
-                                 const unsigned char* pVisibilityAttributes)
+                                 const unsigned char* pVisibilityAttributes,
+                                 const MeshType meshType)
     {
         PSY_DRACO_PROFILE_SECTION("MeshCompression::Impl::Run");
+
+        const bool is_incremental_compression = (meshType == MeshType::INCREMENTAL_MESH);
+
         // reset encode buffer
         mpBuffer->Resize(0);
 
-        // update faces
+        // encode header
         {
-            PSY_DRACO_PROFILE_SECTION("MeshCompression::Impl::Run (update faces)");
+            mHeader.mMajorVersion = 1;
+            mHeader.mMinorVersion = 0;
+            mHeader.mMeshType = meshType;
+            if (!mpBuffer->Encode(&mHeader, sizeof(mHeader)))
+            {
+                mStatus = ::draco::Status(::draco::Status::Code::ERROR, "Failed to encode header.");
+                return eStatus::FAILED;
+            }
+        }
+
+        // update faces if need
+        if (false == is_incremental_compression)
+        {
             const size_t faces_count = indicesCount / 3;
             {
-                // - we can using SetFace() to update a face at an index,
+                // - we can use SetFace() to update a face at an index,
                 //   however, each call will have a check valid index inside the implementation
                 // - instead of, I'm doing an allocation memory first and then push data onto
                 mpMesh->SetNumFaces(faces_count); // allocation purpose
@@ -147,7 +249,6 @@ public:
 
         // update point attributes
         {
-            PSY_DRACO_PROFILE_SECTION("MeshCompression::Impl::Run (update attributes)");
             mpMesh->set_num_points(static_cast<int32_t>(verticesCount));
 
             // vertex positions
@@ -170,7 +271,8 @@ public:
         // run compression
         {
             PSY_DRACO_PROFILE_SECTION("MeshCompression::Impl::Run (EncodeMeshToBuffer)");
-            mStatus = mpEncoder->EncodeMeshToBuffer(*mpMesh, mpBuffer.get());
+            mStatus = mpMeshCompression->Compress(
+                *mpCompressionOptions, *mpMesh, *mpBuffer, is_incremental_compression);
             if (!mStatus.ok())
             {
                 return eStatus::FAILED;
@@ -178,7 +280,7 @@ public:
         }
 
         return eStatus::SUCCEED;
-    }
+    } // MeshCompression::Impl::Run
 
     int mCompressionLevel;
     int mVertexPositionQuantizationBitsCount;
@@ -187,11 +289,13 @@ public:
     int mPositionAttributeId;
     int mVisibilityAttributeId;
 
+    Header mHeader;
     std::unique_ptr<::draco::Mesh> mpMesh;
-    std::unique_ptr<::draco::EncoderBuffer> mpBuffer;
-    std::unique_ptr<::draco::Encoder> mpEncoder;
+    std::shared_ptr<::draco::EncoderBuffer> mpBuffer;
+    std::unique_ptr<CompressionOptions> mpCompressionOptions;
+    std::unique_ptr<MeshEdgeBreakerCompression> mpMeshCompression;
     ::draco::Status mStatus;
-};
+}; // MeshCompression::Impl
 
 MeshCompression::MeshCompression(int compressionLevel,
                                  int vertexPositionQuantizationBitsCount,
@@ -209,19 +313,31 @@ MeshCompression::~MeshCompression()
     mpImpl = nullptr;
 }
 
+bool MeshCompression::IsVisiblityInfoCompressing() const
+{
+    return mpImpl->mHasVisibilityInfo;
+}
+
+void MeshCompression::SetVertexPositionQuantizationBitsCount(const int vertexPositionQuantizationBitsCount)
+{
+    mpImpl->SetVertexPositionQuantizationBitsCount(vertexPositionQuantizationBitsCount);
+}
+
 MeshCompression::eStatus MeshCompression::Run(const float* pVertices,
                                               const size_t vertexStride,
                                               const size_t verticesCount,
                                               const unsigned int* pIndices,
                                               const size_t indicesCount,
-                                              const unsigned char* pVisibilityAttributes)
+                                              const unsigned char* pVisibilityAttributes,
+                                              const MeshType meshType)
 {
     return mpImpl->Run(pVertices,
                        vertexStride,
                        verticesCount,
                        pIndices,
                        indicesCount,
-                       pVisibilityAttributes);
+                       pVisibilityAttributes,
+                       meshType);
 }
 
 const char* MeshCompression::GetCompressedData() const
@@ -247,5 +363,5 @@ const char* MeshCompression::GetLastErrorMessage() const
     return mpImpl->mStatus.error_msg();
 }
 
-}; // namespace draco
-}; // namespace psy
+} // namespace draco
+} // namespace psy

--- a/src/draco/psy/psy_draco_encoder.h
+++ b/src/draco/psy/psy_draco_encoder.h
@@ -27,7 +27,7 @@ public:
         SUCCEED = 0,
         FAILED
     };
-    
+
     /*
     * - compressionLevel (compression level)
     *   + {0 = lowest, 10 = highest} compression ratio.
@@ -44,12 +44,17 @@ public:
                     bool hasVisibilityInfo = false);
     ~MeshCompression();
 
+    void SetVertexPositionQuantizationBitsCount(const int);
+
+    bool IsVisiblityInfoCompressing() const;
+
     eStatus Run(const float* pVertices,
                 const size_t vertexStride,
                 const size_t verticesCount,
                 const unsigned int* pIndices,
                 const size_t indicesCount,
-                const unsigned char* pVisibilityAttributes);
+                const unsigned char* pVisibilityAttributes,
+                const MeshType meshType = MeshType::FULL_MESH);
 
     const char* GetCompressedData() const;
     size_t GetCompressedDataSizeInBytes() const;


### PR DESCRIPTION
This PR includes
- using MeshEdgeBreakerEncoder/Decoder directly in our compression/decompression wrappers
- supporting incremental mesh compression, tries to keep connectivity blob and only encode associated point cloud attributes. So we save much compressed bytes for compression
- having workaround solution because I still not yet find the way to reset/reinitialize attribute encoders/decoders

_Requesting merge to personify-1.0 branch_

//cc @svensht2 