### PR TITLE
draco: Fix add_cxx_preproc_definition() behavior/usage to support setting multiple opts

### DIFF
--- a/cmake/compiler_flags.cmake
+++ b/cmake/compiler_flags.cmake
@@ -152,8 +152,7 @@ function (add_cxx_preproc_definition preproc_def)
   string(FIND "${CMAKE_CXX_FLAGS}" "${preproc_def}" PREPROC_DEF_FOUND)
 
   if (${PREPROC_DEF_FOUND} EQUAL -1)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D${preproc_def}" CACHE STRING ""
-        FORCE)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D${preproc_def}" PARENT_SCOPE)
   endif ()
 endfunction ()
 


### PR DESCRIPTION
- Prev, only last option would take/be appended ... results in needing to
  run build bunches of times and exploding the CMAKE_CXX_FLAGS variable
- Ref: https://github.com/google/draco/issues/306 for related discussion
   - Linked fix uses CMake add_definitions() function, but this applies to
     both C and C++-based compilation