### PR TITLE
WIP, HACK: work on getting draco to compile on VS2017 UWP toolchain

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -771,7 +771,7 @@ elseif(PSY_DRACO_COMPRESSION_ONLY)
       # we need to create a simple wrapper and compile it on visual studio 2015
       # - if we compile it onto a static lib, we will get linking error due to mismatch between two visual studio versions
       # - so, we're compiling the project as shared lib here
-      add_definitions(-DPSY_DRACO_EXPORT=1)
+      add_definitions(-DPSY_DRACO_EXPORT=1 -D_SCL_SECURE_NO_WARNINGS)
       add_library(psy_draco_compression SHARED ${psy_draco_compression_sources})
       set_target_properties(psy_draco_compression PROPERTIES SOVERSION 1)
   else()

--- a/src/draco/core/symbol_coding_utils.h
+++ b/src/draco/core/symbol_coding_utils.h
@@ -41,6 +41,9 @@ typename std::make_unsigned<IntTypeT>::type ConvertSignedIntToSymbol(
   if (val >= 0) {
     return static_cast<UnsignedType>(val) << 1;
   }
+
+  // HACK HACK HACK - VS2017 compilation of draco is not happy with this (and its usage with unsigned types)
+  #pragma warning( suppress : 4146 )  
   val = -(val + 1);  // Map -1 to 0, -2 to -1, etc..
   UnsignedType ret = static_cast<UnsignedType>(val);
   ret <<= 1;

--- a/src/draco/io/parser_utils.cc
+++ b/src/draco/io/parser_utils.cc
@@ -150,6 +150,8 @@ bool ParseSignedInt(DecoderBuffer *buffer, int32_t *value) {
   uint32_t v;
   if (!ParseUnsignedInt(buffer, &v))
     return false;
+  // HACK HACK HACK - VS2017 compilation of draco is not happy with this (and its usage with unsigned types)
+  #pragma warning( suppress : 4146 )  
   *value = (sign < 0) ? -v : v;
   return true;
 }


### PR DESCRIPTION
- Suppressing some errors around unsigned type template params in a "to
  unsigned" helper function
     - Check if addressed upstream, caused locally

DS Update: Didn't see anything that addressed these.